### PR TITLE
fix(course_home_api): avoid anonymous completion lookup in navigation…

### DIFF
--- a/lms/djangoapps/course_home_api/outline/views.py
+++ b/lms/djangoapps/course_home_api/outline/views.py
@@ -602,6 +602,12 @@ class CourseNavigationBlocksView(RetrieveAPIView):
         Dictionary keys are block keys and values are int values
         representing the completion status of the block.
         """
+
+        # Anonymous users have no completion rows; return empty data to avoid
+        # querying BlockCompletion with AnonymousUser for public course navigation.
+        if self.request.user.is_anonymous:
+            return {}
+        
         course_key_string = self.kwargs.get('course_key_string')
         course_key = CourseKey.from_string(course_key_string)
         completions = BlockCompletion.objects.filter(user=self.request.user, context_key=course_key).values_list(


### PR DESCRIPTION
## Description

This PR fixes course outline loading for anonymous users in the Learning MFE by preventing a server error in the course navigation API.

Previously, anonymous requests to `GET /api/course_home/v1/navigation/{course_key}` could raise a `500` when completion data was queried with `AnonymousUser`. This caused the course outline sidebar to fail to render for logged-out users, even when course visibility and waffle settings allowed public access.

This change adds an anonymous-user guard in `CourseNavigationBlocksView.completions_dict`:

* If `request.user` is anonymous, return an empty completion map (`{}`).
* Keep existing outline access filtering logic (`filter_inaccessible_blocks`) unchanged to preserve access control.

**Implications**

* Anonymous users now receive a valid navigation payload instead of a `500`.
* Visibility/access restrictions continue to be enforced by existing processors and filtering.
* No behavior change for authenticated learners/staff.


## Supporting information

**Relevant code / endpoint**

* File: `lms/djangoapps/course_home_api/outline/views.py`
* Endpoint: `GET /api/course_home/v1/navigation/{course_key}`
* Root cause: completion lookup attempted for `AnonymousUser`

**Configuration context (unchanged)**

* `seo.enable_anonymous_courseware_access` enabled
* Course visibility set to `public` or `public_outline`



## Testing instructions

1. Ensure the course is configured with:

   * visibility set to `public` (or `public_outline`)
   * waffle flag `seo.enable_anonymous_courseware_access` enabled
2. Open the courseware URL in an incognito / logged-out browser session.
3. Confirm `GET /api/course_home/v1/navigation/{course_key}` returns `200` (not `500`).
4. Verify the outline sidebar renders in the Learning MFE.
5. Log in as a learner and as staff/admin and confirm outline behavior is unchanged.
6. Optional regression checks:

   * Confirm hidden/inaccessible content remains filtered as before.
   * Confirm no new traceback appears in LMS logs for anonymous navigation requests.



## Deadline

None.



## Other information

**User roles impacted**

* **Learner:** Yes (logged-out / public access flow)
* **Course Author:** No direct impact
* **Developer:** Yes (API behavior and debugging flow)
* **Operator:** Yes (reduced 500s in logs for anonymous navigation requests)

**UI changes**

* UI impact: course outline now renders for anonymous users on eligible `public` / `public_outline` courses.
* Suggested screenshots to attach:

  1. Before: anonymous courseware page with missing/empty outline + API `500`
  2. After: anonymous courseware page with outline visible + API `200`
  3. Network tab response for `/api/course_home/v1/navigation/{course_key}` (before vs after)

**Configuration changes**

* None.

**Dependencies / special concerns**

* No dependency on other PRs.
* No deprecations or migrations.
* Security/access control is unchanged (no relaxation of access restrictions); this only prevents anonymous completion lookup failures.
* No API contract changes.
